### PR TITLE
Fix(filter): graceful error handling of decoding

### DIFF
--- a/.changeset/four-mails-joke.md
+++ b/.changeset/four-mails-joke.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk": patch
+---
+
+Fix to handle errors more gracefully

--- a/src/filter/filters.ts
+++ b/src/filter/filters.ts
@@ -138,28 +138,32 @@ export const handleRegex = (context: any, filter: string): boolean => {
  * @returns The decoded ABI.
  */
 export const handleAbiDecode = (context: any, filter: { $abi: Abi }) => {
-  const sighash = slice(context, 0, 4)
+  try {
+    const sighash = slice(context, 0, 4)
 
-  const { functionName, args = [] } = decodeFunctionData({
-    abi: filter.$abi,
-    data: context,
-  })
+    const { functionName, args = [] } = decodeFunctionData({
+      abi: filter.$abi,
+      data: context,
+    })
 
-  const abiItem = getAbiItem({
-    abi: filter.$abi,
-    name: functionName,
-    args,
-  })
+    const abiItem = getAbiItem({
+      abi: filter.$abi,
+      name: functionName,
+      args,
+    })
 
-  const namedArgs = [...abiItem.inputs].reduce(
-    (acc: Record<string, any>, input, index) => {
-      acc[`${input.name || index}`] = args[index]
-      return acc
-    },
-    {},
-  )
+    const namedArgs = [...abiItem.inputs].reduce(
+      (acc: Record<string, any>, input, index) => {
+        acc[`${input.name || index}`] = args[index]
+        return acc
+      },
+      {},
+    )
 
-  return { ...namedArgs, sighash, functionName }
+    return { ...namedArgs, sighash, functionName }
+  } catch (e) {
+    return null
+  }
 }
 
 /**
@@ -172,14 +176,18 @@ export const handleAbiParamDecode = (
   context: any,
   filter: { $abiParams: string[] },
 ) => {
-  const params = parseAbiParameters(filter.$abiParams.join(', '))
-  const args = decodeAbiParameters(params, context)
-  const namedArgs = params.reduce((acc: Record<string, any>, param, index) => {
-    acc[`${param.name || index}`] = args[index]
-    return acc
-  }, {})
+  try {
+    const params = parseAbiParameters(filter.$abiParams.join(', '))
+    const args = decodeAbiParameters(params, context)
+    const namedArgs = params.reduce((acc: Record<string, any>, param, index) => {
+      acc[`${param.name || index}`] = args[index]
+      return acc
+    }, {})
 
-  return namedArgs
+    return namedArgs
+  } catch (e) {
+    return null
+  }
 }
 
 const operators = {
@@ -231,8 +239,11 @@ export function apply(
   for (const key in filters) {
     if (!Object.hasOwnProperty.call(filters, key)) continue
     if (key in preprocessors) {
-      if (!context) return false
-      context = preprocessors[key as PreprocessorKey](context, filters)
+      const processedContext = preprocessors[key as PreprocessorKey](context, filters)
+      if (processedContext === null) {
+        return false
+      }
+      context = processedContext
       continue
     }
 

--- a/src/filter/filters.ts
+++ b/src/filter/filters.ts
@@ -161,7 +161,7 @@ export const handleAbiDecode = (context: any, filter: { $abi: Abi }) => {
     )
 
     return { ...namedArgs, sighash, functionName }
-  } catch (e) {
+  } catch (_e) {
     return null
   }
 }
@@ -179,13 +179,16 @@ export const handleAbiParamDecode = (
   try {
     const params = parseAbiParameters(filter.$abiParams.join(', '))
     const args = decodeAbiParameters(params, context)
-    const namedArgs = params.reduce((acc: Record<string, any>, param, index) => {
-      acc[`${param.name || index}`] = args[index]
-      return acc
-    }, {})
+    const namedArgs = params.reduce(
+      (acc: Record<string, any>, param, index) => {
+        acc[`${param.name || index}`] = args[index]
+        return acc
+      },
+      {},
+    )
 
     return namedArgs
-  } catch (e) {
+  } catch (_e) {
     return null
   }
 }
@@ -239,7 +242,10 @@ export function apply(
   for (const key in filters) {
     if (!Object.hasOwnProperty.call(filters, key)) continue
     if (key in preprocessors) {
-      const processedContext = preprocessors[key as PreprocessorKey](context, filters)
+      const processedContext = preprocessors[key as PreprocessorKey](
+        context,
+        filters,
+      )
       if (processedContext === null) {
         return false
       }


### PR DESCRIPTION
@jimobrien @jonathandiep 

```
/Users/wumbo/rh/node_modules/@rabbitholegg/questdk/node_modules/viem/src/utils/abi/decodeFunctionData.ts:44
    throw new AbiFunctionSignatureNotFoundError(signature, {
          ^
AbiFunctionSignatureNotFoundError: Encoded function signature "0x87b21efc" not found on ABI.
Make sure you are using the correct ABI and that the function exists on it.
You can look up the signature here: https://openchain.xyz/signatures?query=0x87b21efc.

Docs: https://viem.sh/docs/contract/decodeFunctionData.html
Version: viem@1.5.4
    at decodeFunctionData (/Users/wumbo/rh/node_modules/@rabbitholegg/questdk/node_modules/viem/src/utils/abi/decodeFunctionData.ts:44:11)
    at Object.handleAbiDecode [as $abi] (/Users/wumbo/rh/node_modules/@rabbitholegg/questdk/src/filter/filters.ts:143:57)
    at apply (/Users/wumbo/rh/node_modules/@rabbitholegg/questdk/src/filter/filters.ts:235:54)
    at apply (/Users/wumbo/rh/node_modules/@rabbitholegg/questdk/src/filter/filters.ts:251:12)
    at filterAndProcessTx (/Users/wumbo/rh/src/indexer/filter-and-process-tx.ts:46:65)
    at /Users/wumbo/rh/src/indexer/get-transactions-from-last-processed-block.ts:28:68
    at Array.forEach (<anonymous>)
    at getTransactionsFromLastProcessedBlock (/Users/wumbo/rh/src/indexer/get-transactions-from-last-processed-block.ts:28:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
error Command failed with exit code 1.
```

We're getting this error on the indexer - it seems to indicate that transactions are being fed in that don't align with the plugin that they're getting called for. This fix should resolve that problem but I really don't like how it silences all of the errors since we could theoretically have errors that shouldn't be handled in this way. I could certainly tighten up the scope of the `try` blocks, we could check and see if the ABI has the function, or we could be more restrictive about what gets fed into the functions. I do think it's probably a good idea to make it so these functions fail gracefully though, even if this isn't the approach we use.

Thoughts?