### PR TITLE
Fix(filter): Make delegate optional

### DIFF
--- a/.changeset/big-gifts-retire.md
+++ b/.changeset/big-gifts-retire.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk": patch
+---
+
+Make delegate optional

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -30,7 +30,7 @@ export type MintActionParams = {
 
 export type DelegateActionParams = {
   chainId: number
-  delegate: Address
+  delegate?: Address
   project: Address | string
   contractAddress?: Address
   amount?: bigint | FilterOperator


### PR DESCRIPTION
We might want an action that enables an address to delegate to anyone -- so will need to make the `delegate` field optional