### PR TITLE
Feat(filter): add operator handling to bitmask

### DIFF
--- a/.changeset/empty-pans-cheat.md
+++ b/.changeset/empty-pans-cheat.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk": minor
+---
+
+Adds numerical operator support to bitmask operator

--- a/src/filter/filters.test.ts
+++ b/src/filter/filters.test.ts
@@ -81,6 +81,18 @@ describe('parser', () => {
       expect(handleBitmask(context, filter)).toBe(false)
     })
 
+    test('applies the bitmask and compares the result to the provided value with numerical operators', () => {
+      const context = 0b1100
+      const filter = { bitmask: 0b0100, value: { $gte: 0b0100n }}
+      expect(handleBitmask(context, filter)).toBe(true)
+    })
+
+    test('returns false when the masked context does not equal the provided value with numerical operators', () => {
+      const context = 0b1100
+      const filter = { bitmask: 0b1100, value: { $gte: 0b11100n }}
+      expect(handleBitmask(context, filter)).toBe(false)
+    })
+
     test('correctly handles large numbers', () => {
       const context = '0x123456789abcdef0123456789abcdef0123456789abcdef'
       const filter = {

--- a/src/filter/filters.test.ts
+++ b/src/filter/filters.test.ts
@@ -83,13 +83,13 @@ describe('parser', () => {
 
     test('applies the bitmask and compares the result to the provided value with numerical operators', () => {
       const context = 0b1100
-      const filter = { bitmask: 0b0100, value: { $gte: 0b0100n }}
+      const filter = { bitmask: 0b0100, value: { $gte: 0b0100n } }
       expect(handleBitmask(context, filter)).toBe(true)
     })
 
     test('returns false when the masked context does not equal the provided value with numerical operators', () => {
       const context = 0b1100
-      const filter = { bitmask: 0b1100, value: { $gte: 0b11100n }}
+      const filter = { bitmask: 0b1100, value: { $gte: 0b11100n } }
       expect(handleBitmask(context, filter)).toBe(false)
     })
 

--- a/src/filter/filters.ts
+++ b/src/filter/filters.ts
@@ -180,6 +180,9 @@ export const handleBitmask = (
   filter: BitmaskFilter,
 ): boolean => {
   const maskedContext = BigInt(context) & BigInt(filter.bitmask)
+  if(typeof filter.value === 'object') {
+    return apply(maskedContext as any, filter.value as FilterObject)
+  }
   return maskedContext === BigInt(filter.value)
 }
 

--- a/src/filter/filters.ts
+++ b/src/filter/filters.ts
@@ -177,7 +177,7 @@ export const handleRegex = (context: any, filter: string): boolean => {
  */
 export const handleBitmask = (context: any, filter: BitmaskFilter): boolean => {
   const maskedContext = BigInt(context) & BigInt(filter.bitmask)
-  if(typeof filter.value === 'object') {
+  if (typeof filter.value === 'object') {
     return apply(maskedContext as any, filter.value as FilterObject)
   }
   return maskedContext === BigInt(filter.value)

--- a/src/filter/types.ts
+++ b/src/filter/types.ts
@@ -56,7 +56,7 @@ export type FilterObject = {
 }
 export type BitmaskFilter = {
   bitmask: bigint | number | string;
-  value: bigint | number | string;
+  value: bigint | number | string | NumericOperator;
 };
 export type Filter = Primitive | FilterObject | FilterArray | Abi
 export type FilterArray = Filter[]


### PR DESCRIPTION
Adds the ability to pass numerical operators into the bitmask operator. Didn't build in any deeper recursive support but this also is backwards compatible so plug-ins that already implement this won't break.