### PR TITLE
refactor(questdk): remove unused filter operator functions

### DIFF
--- a/.changeset/yellow-pears-cough.md
+++ b/.changeset/yellow-pears-cough.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk": minor
+---
+
+remove references to unused filter functions

--- a/src/filter/index.ts
+++ b/src/filter/index.ts
@@ -6,13 +6,6 @@ export {
   Equal,
   LessThanOrEqual,
   GreaterThanOrEqual,
-  Or,
-  Any,
-  And,
-  All,
-  Some,
-  First,
-  Last,
 } from './operators.js'
 
 export type {

--- a/src/filter/operators.ts
+++ b/src/filter/operators.ts
@@ -19,12 +19,3 @@ export const LessThanOrEqual = (amount: bigint | number | string) => ({
 export const GreaterThanOrEqual = (amount: bigint | number | string) => ({
   $gte: BigInt(amount),
 })
-
-export const Or = ($or: FilterOperator[]) => ({ $or })
-export const And = ($and: FilterOperator[]) => ({ $and })
-export const Some = ($some: FilterOperator[]) => ({ $some })
-export const First = ($first: FilterOperator) => ({ $first })
-export const Last = ($last: FilterOperator) => ({ $last })
-
-export const Any = Or
-export const All = And

--- a/src/filter/operators.ts
+++ b/src/filter/operators.ts
@@ -1,5 +1,3 @@
-import type { FilterOperator } from './types.js'
-
 export const GreaterThan = (amount: bigint | number | string) => ({
   $gt: BigInt(amount),
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,5 @@ export {
   LessThan,
   LessThanOrEqual,
   GreaterThanOrEqual,
-  Or,
-  And,
-  Some,
-  First,
-  Last,
-  Any,
-  All,
   Equal,
 } from './filter/operators.js'

--- a/src/quests/deployQuest.test.ts
+++ b/src/quests/deployQuest.test.ts
@@ -1,4 +1,3 @@
-import { Any } from '../filter/operators.js'
 import type { LogicalOperator } from '../index.js'
 import { QUEST_FACTORY_ADDRESS } from './constants.js'
 import { deployQuest } from './deployQuest.js'
@@ -22,7 +21,7 @@ describe('deployQuest', () => {
       max: 5000,
     }
 
-    actions = Any([])
+    actions = { $or: [] }
   })
 
   test('should create a transaction with expected values', async () => {


### PR DESCRIPTION
<img width="600" alt="Screenshot 2024-01-20 at 11 11 13 AM" src="https://github.com/rabbitholegg/questdk/assets/62824345/74912bdc-3efe-420e-9215-43a8c3f1633f">


This pr removes the exported functions for each filter operator seen above (And, Or, Some, etc.). These functions are not being used and provide no tangible benefits over just using the raw operators (ie: $or, $and, etc.)