### PR TITLE
fix(creator): standardizing Actiontypes and making all plugin actions optional

### DIFF
--- a/.changeset/pretty-lobsters-report.md
+++ b/.changeset/pretty-lobsters-report.md
@@ -1,0 +1,5 @@
+---
+"@rabbitholegg/questdk": minor
+---
+
+Standardizing ActionParams and no longer requiring some Actions in plugins

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,81 +1,81 @@
-import { type Address } from 'viem'
-import type { FilterOperator, TransactionFilter } from '../filter/types.js'
-import type { PluginActionNotImplementedError } from '../index.js'
+import type { FilterOperator, TransactionFilter } from "../filter/types.js";
+import type { PluginActionNotImplementedError } from "../index.js";
+import { type Address } from "viem";
 
 export type SwapActionParams = {
-  chainId: number
-  contractAddress?: Address
-  tokenIn?: Address
-  tokenOut?: Address
-  amountIn?: bigint | FilterOperator
-  amountOut?: bigint | FilterOperator
-  recipient?: Address
-  deadline?: bigint | FilterOperator
-}
+  chainId: number;
+  contractAddress?: Address;
+  tokenIn?: Address;
+  tokenOut?: Address;
+  amountIn?: bigint | FilterOperator;
+  amountOut?: bigint | FilterOperator;
+  recipient?: Address;
+  deadline?: bigint | FilterOperator;
+};
 
 export type OptionsActionParams = {
-  chainId: number
-  contractAddress?: Address
-  token?: Address
-  amount?: bigint | FilterOperator
-  recipient?: Address
-  orderType?: OrderType
-}
+  chainId: number;
+  contractAddress?: Address;
+  token?: Address;
+  amount?: bigint | FilterOperator;
+  recipient?: Address;
+  orderType?: OrderType;
+};
 
 export type StakeActionParams = {
-  chainId: number
-  contractAddress?: Address
-  tokenOne?: Address
-  amountOne?: bigint | FilterOperator
-  tokenTwo?: Address
-  amountTwo?: bigint | FilterOperator
-  duration?: bigint | FilterOperator
-}
+  chainId: number;
+  contractAddress?: Address;
+  tokenOne?: Address;
+  amountOne?: bigint | FilterOperator;
+  tokenTwo?: Address;
+  amountTwo?: bigint | FilterOperator;
+  duration?: bigint | FilterOperator;
+};
 
 export type BridgeActionParams = {
-  sourceChainId: number
-  destinationChainId: number
-  contractAddress?: Address
-  tokenAddress?: Address
-  amount?: bigint | FilterOperator
-  recipient?: Address
-}
+  sourceChainId: number;
+  destinationChainId: number;
+  contractAddress?: Address;
+  tokenAddress?: Address;
+  amount?: bigint | FilterOperator;
+  recipient?: Address;
+};
 
 export type MintActionParams = {
-  chainId: number
-  contractAddress: Address
-  tokenId?: number
-  amount?: number | FilterOperator
-  recipient?: Address
-}
+  chainId: number;
+  contractAddress: Address;
+  tokenId?: number;
+  amount?: number | FilterOperator;
+  recipient?: Address;
+};
 
-export type BurnActionParams = MintActionParams
+export type BurnActionParams = MintActionParams;
 
 export type QuestActionParams = {
-  chainId: number
-  rewardToken?: Address
-  rewardAmount?: bigint | FilterOperator
-  startTime?: bigint | FilterOperator
-  endTime?: bigint | FilterOperator
-  totalParticipants?: bigint | FilterOperator
-  actionSpec?: string
-}
+  chainId: number;
+  rewardToken?: Address;
+  rewardAmount?: bigint | FilterOperator;
+  startTime?: bigint | FilterOperator;
+  endTime?: bigint | FilterOperator;
+  totalParticipants?: bigint | FilterOperator;
+  actionSpec?: string;
+};
 
 export type DelegateActionParams = {
-  chainId: number
-  delegate?: Address
-  project: Address | string
-  contractAddress?: Address
-  amount?: bigint | FilterOperator
-  delegator?: Address
-}
+  chainId: number;
+  delegate?: Address;
+  project: Address | string;
+  contractAddress?: Address;
+  amount?: bigint | FilterOperator;
+  delegator?: Address;
+};
 
 export type VoteActionParams = {
-  chainId: number
-  project: Address | string
-  support?: bigint | boolean | FilterOperator
-  proposalId?: bigint | FilterOperator
-}
+  chainId: number;
+  project: Address | string;
+  support?: bigint | boolean | FilterOperator;
+  proposalId?: bigint | FilterOperator;
+};
 
 export type ActionParams =
   | SwapActionParams
@@ -85,59 +85,59 @@ export type ActionParams =
   | DelegateActionParams
   | QuestActionParams
   | OptionsActionParams
-  | VoteActionParams
+  | VoteActionParams;
 export interface IActionPlugin {
-  pluginId: string
-  getSupportedChainIds: (task?: ActionType) => Promise<number[]>
+  pluginId: string;
+  getSupportedChainIds: (task?: ActionType) => Promise<number[]>;
   getSupportedTokenAddresses: (
     chainId: number,
     task?: ActionType,
-  ) => Promise<Address[]>
+  ) => Promise<Address[]>;
   bridge?: (
     params: BridgeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   swap?: (
     params: SwapActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   mint?: (
     params: MintActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   stake?: (
     params: StakeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   delegate?: (
     params: DelegateActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   burn?: (
     params: BurnActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   quest?: (
     params: QuestActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   options?: (
     params: OptionsActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   vote?: (
     params: VoteActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
 }
 
 export enum ActionType {
-  Bridge = 'bridge',
-  Stake = 'stake',
-  Swap = 'swap',
-  Mint = 'mint',
-  Burn = 'burn',
-  Quest = 'quest',
-  Deposit = 'deposit',
-  Delegate = 'delegate',
-  Lend = 'lend',
-  Other = 'other',
-  Options = 'options',
-  Vote = 'vote',
+  Bridge = "bridge",
+  Stake = "stake",
+  Swap = "swap",
+  Mint = "mint",
+  Burn = "burn",
+  Quest = "quest",
+  Deposit = "deposit",
+  Delegate = "delegate",
+  Lend = "lend",
+  Other = "other",
+  Options = "options",
+  Vote = "vote",
 }
 
 export enum OrderType {
-  Limit = 'limit',
-  Market = 'market',
+  Limit = "limit",
+  Market = "market",
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,81 +1,81 @@
-import type { FilterOperator, TransactionFilter } from "../filter/types.js";
-import type { PluginActionNotImplementedError } from "../index.js";
-import { type Address } from "viem";
+import type { FilterOperator, TransactionFilter } from '../filter/types.js'
+import type { PluginActionNotImplementedError } from '../index.js'
+import { type Address } from 'viem'
 
 export type SwapActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  tokenIn?: Address;
-  tokenOut?: Address;
-  amountIn?: bigint | FilterOperator;
-  amountOut?: bigint | FilterOperator;
-  recipient?: Address;
-  deadline?: bigint | FilterOperator;
-};
+  chainId: number
+  contractAddress?: Address
+  tokenIn?: Address
+  tokenOut?: Address
+  amountIn?: bigint | FilterOperator
+  amountOut?: bigint | FilterOperator
+  recipient?: Address
+  deadline?: bigint | FilterOperator
+}
 
 export type OptionsActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  token?: Address;
-  amount?: bigint | FilterOperator;
-  recipient?: Address;
-  orderType?: OrderType;
-};
+  chainId: number
+  contractAddress?: Address
+  token?: Address
+  amount?: bigint | FilterOperator
+  recipient?: Address
+  orderType?: OrderType
+}
 
 export type StakeActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  tokenOne?: Address;
-  amountOne?: bigint | FilterOperator;
-  tokenTwo?: Address;
-  amountTwo?: bigint | FilterOperator;
-  duration?: bigint | FilterOperator;
-};
+  chainId: number
+  contractAddress?: Address
+  tokenOne?: Address
+  amountOne?: bigint | FilterOperator
+  tokenTwo?: Address
+  amountTwo?: bigint | FilterOperator
+  duration?: bigint | FilterOperator
+}
 
 export type BridgeActionParams = {
-  sourceChainId: number;
-  destinationChainId: number;
-  contractAddress?: Address;
-  tokenAddress?: Address;
-  amount?: bigint | FilterOperator;
-  recipient?: Address;
-};
+  sourceChainId: number
+  destinationChainId: number
+  contractAddress?: Address
+  tokenAddress?: Address
+  amount?: bigint | FilterOperator
+  recipient?: Address
+}
 
 export type MintActionParams = {
-  chainId: number;
-  contractAddress: Address;
-  tokenId?: number;
-  amount?: number | FilterOperator;
-  recipient?: Address;
-};
+  chainId: number
+  contractAddress: Address
+  tokenId?: number
+  amount?: number | FilterOperator
+  recipient?: Address
+}
 
-export type BurnActionParams = MintActionParams;
+export type BurnActionParams = MintActionParams
 
 export type QuestActionParams = {
-  chainId: number;
-  rewardToken?: Address;
-  rewardAmount?: bigint | FilterOperator;
-  startTime?: bigint | FilterOperator;
-  endTime?: bigint | FilterOperator;
-  totalParticipants?: bigint | FilterOperator;
-  actionSpec?: string;
-};
+  chainId: number
+  rewardToken?: Address
+  rewardAmount?: bigint | FilterOperator
+  startTime?: bigint | FilterOperator
+  endTime?: bigint | FilterOperator
+  totalParticipants?: bigint | FilterOperator
+  actionSpec?: string
+}
 
 export type DelegateActionParams = {
-  chainId: number;
-  delegate?: Address;
-  project: Address | string;
-  contractAddress?: Address;
-  amount?: bigint | FilterOperator;
-  delegator?: Address;
-};
+  chainId: number
+  delegate?: Address
+  project: Address | string
+  contractAddress?: Address
+  amount?: bigint | FilterOperator
+  delegator?: Address
+}
 
 export type VoteActionParams = {
-  chainId: number;
-  project: Address | string;
-  support?: bigint | boolean | FilterOperator;
-  proposalId?: bigint | FilterOperator;
-};
+  chainId: number
+  project: Address | string
+  support?: bigint | boolean | FilterOperator
+  proposalId?: bigint | FilterOperator
+}
 
 export type ActionParams =
   | SwapActionParams
@@ -85,59 +85,59 @@ export type ActionParams =
   | DelegateActionParams
   | QuestActionParams
   | OptionsActionParams
-  | VoteActionParams;
+  | VoteActionParams
 export interface IActionPlugin {
-  pluginId: string;
-  getSupportedChainIds: (task?: ActionType) => Promise<number[]>;
+  pluginId: string
+  getSupportedChainIds: (task?: ActionType) => Promise<number[]>
   getSupportedTokenAddresses: (
     chainId: number,
     task?: ActionType,
-  ) => Promise<Address[]>;
+  ) => Promise<Address[]>
   bridge?: (
     params: BridgeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   swap?: (
     params: SwapActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   mint?: (
     params: MintActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   stake?: (
     params: StakeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   delegate?: (
     params: DelegateActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   burn?: (
     params: BurnActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   quest?: (
     params: QuestActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   options?: (
     params: OptionsActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   vote?: (
     params: VoteActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
 }
 
 export enum ActionType {
-  Bridge = "bridge",
-  Stake = "stake",
-  Swap = "swap",
-  Mint = "mint",
-  Burn = "burn",
-  Quest = "quest",
-  Deposit = "deposit",
-  Delegate = "delegate",
-  Lend = "lend",
-  Other = "other",
-  Options = "options",
-  Vote = "vote",
+  Bridge = 'bridge',
+  Stake = 'stake',
+  Swap = 'swap',
+  Mint = 'mint',
+  Burn = 'burn',
+  Quest = 'quest',
+  Deposit = 'deposit',
+  Delegate = 'delegate',
+  Lend = 'lend',
+  Other = 'other',
+  Options = 'options',
+  Vote = 'vote',
 }
 
 export enum OrderType {
-  Limit = "limit",
-  Market = "market",
+  Limit = 'limit',
+  Market = 'market',
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,81 +1,81 @@
-import type { FilterOperator, TransactionFilter } from '../filter/types.js'
-import type { PluginActionNotImplementedError } from '../index.js'
-import { type Address } from 'viem'
+import { type Address } from "viem";
+import type { FilterOperator, TransactionFilter } from "../filter/types.js";
+import type { PluginActionNotImplementedError } from "../index.js";
 
 export type SwapActionParams = {
-  chainId: number
-  contractAddress?: Address
-  tokenIn?: Address
-  tokenOut?: Address
-  amountIn?: bigint | FilterOperator
-  amountOut?: bigint | FilterOperator
-  recipient?: Address
-  deadline?: bigint | FilterOperator
-}
+  chainId: number;
+  contractAddress?: Address;
+  tokenIn?: Address;
+  tokenOut?: Address;
+  amountIn?: bigint | FilterOperator;
+  amountOut?: bigint | FilterOperator;
+  recipient?: Address;
+  deadline?: bigint | FilterOperator;
+};
 
 export type OptionsActionParams = {
-  chainId: number
-  contractAddress?: Address
-  token?: Address
-  amount?: bigint | FilterOperator
-  recipient?: Address
-  orderType?: OrderType
-}
+  chainId: number;
+  contractAddress?: Address;
+  token?: Address;
+  amount?: bigint | FilterOperator;
+  recipient?: Address;
+  orderType?: OrderType;
+};
 
 export type StakeActionParams = {
-  chainId: number
-  contractAddress?: Address
-  tokenOne?: Address
-  amountOne?: bigint | FilterOperator
-  tokenTwo?: Address
-  amountTwo?: bigint | FilterOperator
-  duration?: bigint | FilterOperator
-}
+  chainId: number;
+  contractAddress?: Address;
+  tokenOne?: Address;
+  amountOne?: bigint | FilterOperator;
+  tokenTwo?: Address;
+  amountTwo?: bigint | FilterOperator;
+  duration?: bigint | FilterOperator;
+};
 
 export type BridgeActionParams = {
-  sourceChainId: number
-  destinationChainId: number
-  contractAddress?: Address
-  tokenAddress?: Address
-  amount?: bigint | FilterOperator
-  recipient?: Address
-}
+  sourceChainId: number;
+  destinationChainId: number;
+  contractAddress?: Address;
+  tokenAddress?: Address;
+  amount?: bigint | FilterOperator;
+  recipient?: Address;
+};
 
 export type MintActionParams = {
-  chainId: number
-  contractAddress: Address
-  tokenId?: number
-  amount?: number | FilterOperator
-  recipient?: Address
-}
+  chainId: number;
+  contractAddress: Address;
+  tokenId?: number;
+  amount?: number | FilterOperator;
+  recipient?: Address;
+};
 
-export type BurnActionParams = MintActionParams
+export type BurnActionParams = MintActionParams;
 
 export type QuestActionParams = {
-  chainId: number
-  rewardToken?: Address
-  rewardAmount?: bigint | FilterOperator
-  startTime?: bigint | FilterOperator
-  endTime?: bigint | FilterOperator
-  totalParticipants?: bigint | FilterOperator
-  actionSpec?: string
-}
+  chainId: number;
+  rewardToken?: Address;
+  rewardAmount?: bigint | FilterOperator;
+  startTime?: bigint | FilterOperator;
+  endTime?: bigint | FilterOperator;
+  totalParticipants?: bigint | FilterOperator;
+  actionSpec?: string;
+};
 
 export type DelegateActionParams = {
-  chainId: number
-  delegate?: Address
-  project: Address | string
-  contractAddress?: Address
-  amount?: bigint | FilterOperator
-  delegator?: Address
-}
+  chainId: number;
+  delegate?: Address;
+  project: Address | string;
+  contractAddress?: Address;
+  amount?: bigint | FilterOperator;
+  delegator?: Address;
+};
 
 export type VoteActionParams = {
-  chainId: number
-  project: Address | string
-  support?: bigint | boolean | FilterOperator
-  proposalId?: bigint | FilterOperator
-}
+  chainId: number;
+  project: Address | string;
+  support?: bigint | boolean | FilterOperator;
+  proposalId?: bigint | FilterOperator;
+};
 
 export type ActionParams =
   | SwapActionParams
@@ -85,59 +85,59 @@ export type ActionParams =
   | DelegateActionParams
   | QuestActionParams
   | OptionsActionParams
-  | VoteActionParams
+  | VoteActionParams;
 export interface IActionPlugin {
-  pluginId: string
-  getSupportedChainIds: (task?: ActionType) => Promise<number[]>
+  pluginId: string;
+  getSupportedChainIds: (task?: ActionType) => Promise<number[]>;
   getSupportedTokenAddresses: (
     chainId: number,
     task?: ActionType,
-  ) => Promise<Address[]>
-  bridge: (
+  ) => Promise<Address[]>;
+  bridge?: (
     params: BridgeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
-  swap: (
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  swap?: (
     params: SwapActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
-  mint: (
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  mint?: (
     params: MintActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   stake?: (
     params: StakeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   delegate?: (
     params: DelegateActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   burn?: (
-    params: DelegateActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+    params: BurnActionParams,
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   quest?: (
     params: QuestActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   options?: (
     params: OptionsActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
   vote?: (
     params: VoteActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
 }
 
 export enum ActionType {
-  Bridge = 'bridge',
-  Stake = 'stake',
-  Swap = 'swap',
-  Mint = 'mint',
-  Burn = 'burn',
-  Quest = 'quest',
-  Deposit = 'deposit',
-  Delegate = 'delegate',
-  Lend = 'lend',
-  Other = 'other',
-  Options = 'options',
-  Vote = 'vote',
+  Bridge = "bridge",
+  Stake = "stake",
+  Swap = "swap",
+  Mint = "mint",
+  Burn = "burn",
+  Quest = "quest",
+  Deposit = "deposit",
+  Delegate = "delegate",
+  Lend = "lend",
+  Other = "other",
+  Options = "options",
+  Vote = "vote",
 }
 
 export enum OrderType {
-  Limit = 'limit',
-  Market = 'market',
+  Limit = "limit",
+  Market = "market",
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,81 +1,81 @@
-import { type Address } from "viem";
-import type { FilterOperator, TransactionFilter } from "../filter/types.js";
-import type { PluginActionNotImplementedError } from "../index.js";
+import { type Address } from 'viem'
+import type { FilterOperator, TransactionFilter } from '../filter/types.js'
+import type { PluginActionNotImplementedError } from '../index.js'
 
 export type SwapActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  tokenIn?: Address;
-  tokenOut?: Address;
-  amountIn?: bigint | FilterOperator;
-  amountOut?: bigint | FilterOperator;
-  recipient?: Address;
-  deadline?: bigint | FilterOperator;
-};
+  chainId: number
+  contractAddress?: Address
+  tokenIn?: Address
+  tokenOut?: Address
+  amountIn?: bigint | FilterOperator
+  amountOut?: bigint | FilterOperator
+  recipient?: Address
+  deadline?: bigint | FilterOperator
+}
 
 export type OptionsActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  token?: Address;
-  amount?: bigint | FilterOperator;
-  recipient?: Address;
-  orderType?: OrderType;
-};
+  chainId: number
+  contractAddress?: Address
+  token?: Address
+  amount?: bigint | FilterOperator
+  recipient?: Address
+  orderType?: OrderType
+}
 
 export type StakeActionParams = {
-  chainId: number;
-  contractAddress?: Address;
-  tokenOne?: Address;
-  amountOne?: bigint | FilterOperator;
-  tokenTwo?: Address;
-  amountTwo?: bigint | FilterOperator;
-  duration?: bigint | FilterOperator;
-};
+  chainId: number
+  contractAddress?: Address
+  tokenOne?: Address
+  amountOne?: bigint | FilterOperator
+  tokenTwo?: Address
+  amountTwo?: bigint | FilterOperator
+  duration?: bigint | FilterOperator
+}
 
 export type BridgeActionParams = {
-  sourceChainId: number;
-  destinationChainId: number;
-  contractAddress?: Address;
-  tokenAddress?: Address;
-  amount?: bigint | FilterOperator;
-  recipient?: Address;
-};
+  sourceChainId: number
+  destinationChainId: number
+  contractAddress?: Address
+  tokenAddress?: Address
+  amount?: bigint | FilterOperator
+  recipient?: Address
+}
 
 export type MintActionParams = {
-  chainId: number;
-  contractAddress: Address;
-  tokenId?: number;
-  amount?: number | FilterOperator;
-  recipient?: Address;
-};
+  chainId: number
+  contractAddress: Address
+  tokenId?: number
+  amount?: number | FilterOperator
+  recipient?: Address
+}
 
-export type BurnActionParams = MintActionParams;
+export type BurnActionParams = MintActionParams
 
 export type QuestActionParams = {
-  chainId: number;
-  rewardToken?: Address;
-  rewardAmount?: bigint | FilterOperator;
-  startTime?: bigint | FilterOperator;
-  endTime?: bigint | FilterOperator;
-  totalParticipants?: bigint | FilterOperator;
-  actionSpec?: string;
-};
+  chainId: number
+  rewardToken?: Address
+  rewardAmount?: bigint | FilterOperator
+  startTime?: bigint | FilterOperator
+  endTime?: bigint | FilterOperator
+  totalParticipants?: bigint | FilterOperator
+  actionSpec?: string
+}
 
 export type DelegateActionParams = {
-  chainId: number;
-  delegate?: Address;
-  project: Address | string;
-  contractAddress?: Address;
-  amount?: bigint | FilterOperator;
-  delegator?: Address;
-};
+  chainId: number
+  delegate?: Address
+  project: Address | string
+  contractAddress?: Address
+  amount?: bigint | FilterOperator
+  delegator?: Address
+}
 
 export type VoteActionParams = {
-  chainId: number;
-  project: Address | string;
-  support?: bigint | boolean | FilterOperator;
-  proposalId?: bigint | FilterOperator;
-};
+  chainId: number
+  project: Address | string
+  support?: bigint | boolean | FilterOperator
+  proposalId?: bigint | FilterOperator
+}
 
 export type ActionParams =
   | SwapActionParams
@@ -85,59 +85,59 @@ export type ActionParams =
   | DelegateActionParams
   | QuestActionParams
   | OptionsActionParams
-  | VoteActionParams;
+  | VoteActionParams
 export interface IActionPlugin {
-  pluginId: string;
-  getSupportedChainIds: (task?: ActionType) => Promise<number[]>;
+  pluginId: string
+  getSupportedChainIds: (task?: ActionType) => Promise<number[]>
   getSupportedTokenAddresses: (
     chainId: number,
     task?: ActionType,
-  ) => Promise<Address[]>;
+  ) => Promise<Address[]>
   bridge?: (
     params: BridgeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   swap?: (
     params: SwapActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   mint?: (
     params: MintActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   stake?: (
     params: StakeActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   delegate?: (
     params: DelegateActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   burn?: (
     params: BurnActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   quest?: (
     params: QuestActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   options?: (
     params: OptionsActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
   vote?: (
     params: VoteActionParams,
-  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>;
+  ) => Promise<TransactionFilter> | Promise<PluginActionNotImplementedError>
 }
 
 export enum ActionType {
-  Bridge = "bridge",
-  Stake = "stake",
-  Swap = "swap",
-  Mint = "mint",
-  Burn = "burn",
-  Quest = "quest",
-  Deposit = "deposit",
-  Delegate = "delegate",
-  Lend = "lend",
-  Other = "other",
-  Options = "options",
-  Vote = "vote",
+  Bridge = 'bridge',
+  Stake = 'stake',
+  Swap = 'swap',
+  Mint = 'mint',
+  Burn = 'burn',
+  Quest = 'quest',
+  Deposit = 'deposit',
+  Delegate = 'delegate',
+  Lend = 'lend',
+  Other = 'other',
+  Options = 'options',
+  Vote = 'vote',
 }
 
 export enum OrderType {
-  Limit = "limit",
-  Market = "market",
+  Limit = 'limit',
+  Market = 'market',
 }


### PR DESCRIPTION
I couldn't find a reason that bridge, swap, and mint are required while all other action types are optional - they're already typed to throw an error.

Also, Burn was using DelegateActionParams so I made it use BurnActionParams - no plugins are using Burn yet